### PR TITLE
BIT-236 DW releasing in case of outdated deposit balance throws an ex…

### DIFF
--- a/src/Lykke.Job.BlockchainCashinDetector/Workflow/Sagas/CashinSaga.cs
+++ b/src/Lykke.Job.BlockchainCashinDetector/Workflow/Sagas/CashinSaga.cs
@@ -344,16 +344,15 @@ namespace Lykke.Job.BlockchainCashinDetector.Workflow.Sagas
 
             var transitionResult = aggregate.OnDepositWalletLockReleased();
 
-            if (aggregate.Result == CashinResult.OutdatedBalance)
-            {
-                await _cashinRepository.SaveAsync(aggregate);
-
-                return;
-            }
 
             if (transitionResult.ShouldSaveAggregate())
             {
                 await _cashinRepository.SaveAsync(aggregate);
+            }
+
+            if (aggregate.Result == CashinResult.OutdatedBalance)
+            {
+                return;
             }
 
             // Sending the "off-blockchain operation" event, if needed.

--- a/src/Lykke.Job.BlockchainCashinDetector/Workflow/Sagas/CashinSaga.cs
+++ b/src/Lykke.Job.BlockchainCashinDetector/Workflow/Sagas/CashinSaga.cs
@@ -344,6 +344,13 @@ namespace Lykke.Job.BlockchainCashinDetector.Workflow.Sagas
 
             var transitionResult = aggregate.OnDepositWalletLockReleased();
 
+            if (aggregate.Result == CashinResult.OutdatedBalance)
+            {
+                await _cashinRepository.SaveAsync(aggregate);
+
+                return;
+            }
+
             if (transitionResult.ShouldSaveAggregate())
             {
                 await _cashinRepository.SaveAsync(aggregate);


### PR DESCRIPTION
…ception

In case of outdated deposit balance, DepositWalletLockReleasedEvent handler in the CashinSaga throws InvalidOperationException("IsDustCashin should be not null here"). Actually IsDustCashin can be null here in case  when aggregate.Result is OutdatedBalance. We should check the aggregate.Result here and if it's OutdatedBalance, then we should just save aggregate and send no commands. We don't need notifications here, since there is no cashin were made nor failed. Is just a dummy cashin.

Outdated balance means that before sending the LockDepositWalletCommand, the balance returned by the integration was actual relative to the enrolled balance, but after locking the DW, balance became outdated. Likely due to enrolled balance being changed by a previous deposit between these two checks. This is the implementation of the "double checking lock" pattern.